### PR TITLE
Update README to use a positional api_key argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If bundler is not being used to manage dependencies, install the gem by executin
 require "cohere"
 
 client = Cohere::Client.new(
-  api_key: ENV['COHERE_API_KEY']
+  ENV['COHERE_API_KEY']
 )
 ```
 ### Generate


### PR DESCRIPTION
The README shows that the client should be initialized with a named argument. This changed in 0.9. to use a positional argument:

https://github.com/andreibondarev/cohere-ruby/pull/8