### PR TITLE
Add input_type argument for embed endpoint

### DIFF
--- a/lib/cohere/client.rb
+++ b/lib/cohere/client.rb
@@ -53,11 +53,13 @@ module Cohere
     def embed(
       texts:,
       model: nil,
+      input_type: nil,
       truncate: nil
     )
       response = connection.post("embed") do |req|
         req.body = {texts: texts}
         req.body[:model] = model if model
+        req.body[:input_type] = model if input_type
         req.body[:truncate] = truncate if truncate
       end
       response.body

--- a/lib/cohere/client.rb
+++ b/lib/cohere/client.rb
@@ -59,7 +59,7 @@ module Cohere
       response = connection.post("embed") do |req|
         req.body = {texts: texts}
         req.body[:model] = model if model
-        req.body[:input_type] = model if input_type
+        req.body[:input_type] = input_type if input_type
         req.body[:truncate] = truncate if truncate
       end
       response.body


### PR DESCRIPTION
Newer embedding models require an `input_type` argument. This change adds the `input_type` argument to the embed method.